### PR TITLE
Simplify error handling

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,13 +23,19 @@ pub enum Terminal {
     Konsole,
     Kitty,
     Ghostty,
-    Tabby
+    Tabby,
 }
 
 #[derive(Debug)]
 pub enum Error {
     NotSupported,
     IOError(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::IOError(err)
+    }
 }
 
 impl fmt::Display for Error {
@@ -48,7 +54,7 @@ pub fn open(
 
     #[cfg(target_os = "windows")]
     return terminal_windows::open(terminal, command, env_vars);
-    
+
     #[cfg(target_os = "linux")]
     return terminal_linux::open(terminal, command, env_vars);
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,7 +23,7 @@ pub enum Terminal {
     Konsole,
     Kitty,
     Ghostty,
-    Tabby,
+    Tabby
 }
 
 #[derive(Debug)]

--- a/lib/src/terminal_linux.rs
+++ b/lib/src/terminal_linux.rs
@@ -1,17 +1,20 @@
 use crate::{Error, Terminal};
 use std::collections::HashMap;
 use std::env::home_dir;
+use std::io::ErrorKind;
+use std::process::Child;
 use std::{
     env::temp_dir,
     fs,
     fs::File,
+    io,
     io::Write,
     os::unix::fs::PermissionsExt,
     path::PathBuf,
     process::{Command, Stdio},
 };
 
-type Launcher = fn(&mut Command, &str) -> Result<(), Error>;
+type Launcher = fn(&mut Command, &str) -> io::Result<Child>;
 
 pub(crate) fn open(
     terminal: Terminal,
@@ -19,13 +22,12 @@ pub(crate) fn open(
     env_vars: HashMap<String, String>,
 ) -> Result<(), Error> {
     let (mut cmd, launcher) = new_command(terminal, env_vars)?;
-    if let Some(path) = write_temp_script(command)?.to_str() {
-        launcher(&mut cmd, path)
+    let launch_script = write_temp_script(command)?;
+    if let Some(path) = launch_script.to_str() {
+        launcher(&mut cmd, path)?;
+        Ok(())
     } else {
-        Err(Error::IOError(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "Invalid path",
-        )))
+        Err(new_error("Invalid path").into())
     }
 }
 
@@ -36,11 +38,11 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 
 fn command_name(terminal: Terminal) -> Result<(&'static str, Launcher), Error> {
     let map = match terminal {
-        Terminal::GNOMETerminal => ("gnome-terminal", open_gnome_terminal as Launcher),
-        Terminal::Konsole => ("konsole", open_konsole as Launcher),
-        Terminal::Kitty => ("kitty", open_kitty as Launcher),
-        Terminal::Ghostty => ("ghostty", open_ghostty as Launcher),
-        Terminal::Warp => ("warp-terminal", open_warp as Launcher),
+        Terminal::GNOMETerminal => ("gnome-terminal", spawn_gnome_terminal as Launcher),
+        Terminal::Konsole => ("konsole", spawn_konsole as Launcher),
+        Terminal::Kitty => ("kitty", spawn_kitty as Launcher),
+        Terminal::Ghostty => ("ghostty", spawn_ghostty as Launcher),
+        Terminal::Warp => ("warp-terminal", spawn_warp as Launcher),
         _ => Err(Error::NotSupported)?,
     };
     Ok(map)
@@ -50,50 +52,33 @@ fn new_command(term: Terminal, env: HashMap<String, String>) -> Result<(Command,
     let (bin, launcher) = command_name(term)?;
     let mut cmd = Command::new(bin);
     cmd.envs(env).current_dir(cwd());
-
     if std::env::var("APPIMAGE").is_ok() {
         // AppImage sets its own PYTHONHOME and PYTHONPATH variables and we don't want that to leak into the new terminal
         // If we don't remove them, some terminals like gnome-terminal and kitty won't launch on AppImage
         cmd.env_remove("PYTHONHOME").env_remove("PYTHONPATH");
     }
-
     Ok((cmd, launcher))
 }
 
-fn open_warp(command: &mut Command, path: &str) -> Result<(), Error> {
+fn spawn_warp(command: &mut Command, path: &str) -> io::Result<Child> {
     write_warp_launch_config(cwd().to_string_lossy().as_ref(), path)?;
-    match command.args(["warp://launch/aptakube.yaml"]).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+    command.args(["warp://launch/aptakube.yaml"]).spawn()
 }
 
-fn open_ghostty(commnad: &mut Command, path: &str) -> Result<(), Error> {
-    match commnad.args(["-e", path]).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+fn spawn_ghostty(commnad: &mut Command, path: &str) -> io::Result<Child> {
+    commnad.args(["-e", path]).spawn()
 }
 
-fn open_kitty(command: &mut Command, path: &str) -> Result<(), Error> {
-    match command.args([path]).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+fn spawn_konsole(command: &mut Command, path: &str) -> io::Result<Child> {
+    command.args(["-e", path]).spawn()
 }
 
-fn open_konsole(command: &mut Command, path: &str) -> Result<(), Error> {
-    match command.args(["-e", path]).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+fn spawn_kitty(command: &mut Command, path: &str) -> io::Result<Child> {
+    command.args([path]).spawn()
 }
 
-fn open_gnome_terminal(command: &mut Command, path: &str) -> Result<(), Error> {
-    match command.args(["--", path]).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+fn spawn_gnome_terminal(command: &mut Command, path: &str) -> io::Result<Child> {
+    command.args(["--", path]).spawn()
 }
 
 fn binary_exists(name: &str) -> bool {
@@ -109,7 +94,7 @@ fn binary_exists(name: &str) -> bool {
     }
 }
 
-fn write_warp_launch_config(cwd: &str, script_path: &str) -> Result<(), Error> {
+fn write_warp_launch_config(cwd: &str, script_path: &str) -> io::Result<()> {
     // Find out where to store the launch config
     // https://docs.warp.dev/features/sessions/launch-configurations
     // ${XDG_DATA_HOME:-$HOME/.local/share}/warp-terminal/launch_configurations/
@@ -118,15 +103,15 @@ fn write_warp_launch_config(cwd: &str, script_path: &str) -> Result<(), Error> {
         Err(_) => {
             let home = match std::env::var("HOME") {
                 Ok(val) => val,
-                Err(_) => return Err(Error::NotSupported),
+                Err(_) => return Err(new_error("XDG_DATA_HOME or HOME are not set")),
             };
             format!("{}/.local/share", home)
         }
     };
     let warp_dir = format!("{}/warp-terminal/launch_configurations", xdg_data_home);
-    fs::create_dir_all(&warp_dir).map_err(Error::IOError)?;
+    fs::create_dir_all(&warp_dir)?;
     let file_path = PathBuf::from(format!("{}/aptakube.yaml", warp_dir));
-    let mut f = File::create(&file_path).map_err(Error::IOError)?;
+    let mut f = File::create(&file_path)?;
     let content = format!(
         r#"---
 name: Aptakube
@@ -141,30 +126,29 @@ windows:
             - exec: {}"#,
         cwd, script_path
     );
-    f.write_all(content.as_bytes())
-        .and_then(|_| f.flush())
-        .map_err(Error::IOError)?;
-    Ok(())
+    f.write_all(content.as_bytes()).and_then(|_| f.flush())
 }
 
 fn write_temp_script(command: &str) -> Result<PathBuf, Error> {
     let dir = temp_dir();
     let path = dir.join("run-in-terminal.sh");
 
-    let mut f = File::create(&path).map_err(Error::IOError)?;
+    let mut f = File::create(&path)?;
 
     let content = if command.is_empty() {
         format!("#!/usr/bin/env sh\n\ncd $HOME\nexec $SHELL")
     } else {
         format!("#!/usr/bin/env sh\n\ncd $HOME\n{}\nexec $SHELL", command)
     };
-    f.write_all(content.as_bytes())
-        .and_then(|_| f.flush())
-        .map_err(Error::IOError)?;
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).map_err(Error::IOError)?;
+    f.write_all(content.as_bytes()).and_then(|_| f.flush())?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755))?;
     Ok(path)
 }
 
 fn cwd() -> PathBuf {
     home_dir().unwrap_or(temp_dir())
+}
+
+fn new_error(message: &str) -> io::Error {
+    io::Error::new(ErrorKind::Other, message)
 }

--- a/lib/src/terminal_linux.rs
+++ b/lib/src/terminal_linux.rs
@@ -39,9 +39,9 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 fn command_name(terminal: Terminal) -> Result<(&'static str, Launcher), Error> {
     let map = match terminal {
         Terminal::GNOMETerminal => ("gnome-terminal", spawn_gnome_terminal as Launcher),
-        Terminal::Konsole => ("konsole", spawn_konsole as Launcher),
+        Terminal::Konsole => ("konsole", spawn_with_e_flag as Launcher),
+        Terminal::Ghostty => ("ghostty", spawn_with_e_flag as Launcher),
         Terminal::Kitty => ("kitty", spawn_kitty as Launcher),
-        Terminal::Ghostty => ("ghostty", spawn_ghostty as Launcher),
         Terminal::Warp => ("warp-terminal", spawn_warp as Launcher),
         _ => Err(Error::NotSupported)?,
     };
@@ -65,11 +65,7 @@ fn spawn_warp(command: &mut Command, path: &str) -> io::Result<Child> {
     command.args(["warp://launch/aptakube.yaml"]).spawn()
 }
 
-fn spawn_ghostty(commnad: &mut Command, path: &str) -> io::Result<Child> {
-    commnad.args(["-e", path]).spawn()
-}
-
-fn spawn_konsole(command: &mut Command, path: &str) -> io::Result<Child> {
+fn spawn_with_e_flag(command: &mut Command, path: &str) -> io::Result<Child> {
     command.args(["-e", path]).spawn()
 }
 

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -1,7 +1,7 @@
+use std::collections::HashMap;
 use std::env::{self, home_dir};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::collections::HashMap;
 use once_cell::sync::Lazy;
 
 use std::fs::{self, File};
@@ -10,9 +10,11 @@ use std::{env::temp_dir, io::Write, path::PathBuf};
 
 use crate::{Error, Terminal};
 
-const DEFAULT_SHELL: &str = "zsh";
-
-pub(crate) fn open(terminal: Terminal, command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
+pub(crate) fn open(
+    terminal: Terminal,
+    command: &str,
+    env_vars: HashMap<String, String>,
+) -> Result<(), Error> {
     return match terminal {
         Terminal::AppleTerminal => open_with_app("terminal", command, env_vars),
         Terminal::ITerm2 => open_with_app("iterm", command, env_vars),
@@ -22,7 +24,7 @@ pub(crate) fn open(terminal: Terminal, command: &str, env_vars: HashMap<String, 
         Terminal::Tabby => open_with_tabby(command, env_vars),
         Terminal::WezTerm => open_with_wezterm(command, env_vars),
         _ => return Err(Error::NotSupported),
-    }
+    };
 }
 
 pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
@@ -37,29 +39,18 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
         _ => return Err(Error::NotSupported),
     };
 
-
-    let found = match Command::new("osascript")
-        .arg("-e")
-        .arg(format!("id of application \"{}\"", app_name))
+    Command::new("osascript")
+        .args(["-e", format!("id of application \"{}\"", app_name)])
         .stderr(Stdio::null())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .status()
-    {
-        Ok(status) => status.success(),
-        Err(err) => return Err(Error::IOError(err)),
-    };
-
-   return Ok(found)
 }
 
 fn open_with_app(app: &str, command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let path = write_temp_script(command, env_vars)?;
-
-    match Command::new("open").arg("-a").arg(app).arg(path).spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+    Command::new("open").args(["-a", app, path]).spawn()?;
+    Ok(())
 }
 
 fn open_with_wezterm(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
@@ -129,7 +120,7 @@ fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result
     let dir = temp_dir();
     let path = dir.join("run-in-terminal.sh");
 
-    let mut f = File::create(&path).map_err(Error::IOError)?;
+    let mut f = File::create(&path)?;
 
     let content = if command.is_empty() {
         format!("{}\n\ncd $HOME\n{} exec $SHELL", SHELL.to_string(), stringify_env_vars(env_vars))
@@ -137,18 +128,10 @@ fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result
         format!("{}\n\ncd $HOME\n{} {}\nexec $SHELL", SHELL.to_string(), stringify_env_vars(env_vars), command)
     };
 
-    f.write_all(content.as_bytes()).and_then(|_| f.flush()).map_err(Error::IOError)?;
+    f.write_all(content.as_bytes()).and_then(|_| f.flush())?;
 
     let permissions = fs::Permissions::from_mode(0o755);
-    fs::set_permissions(&path, permissions).map_err(Error::IOError)?;
+    fs::set_permissions(&path, permissions)?;
 
     Ok(path)
-}
-
-fn stringify_env_vars(env_vars: HashMap<String, String>) -> String {
-    env_vars
-        .iter()
-        .map(|(key, value)| format!("{}='{}'", key, value))
-        .collect::<Vec<String>>()
-        .join(" ")
 }

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -49,7 +49,10 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 
 fn open_with_app(app: &str, command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let path = write_temp_script(command, env_vars)?;
-    Command::new("open").args(["-a", app, path]).spawn()?;
+    Command::new("open")
+        .envs(env_vars)
+        .args(["-a", app, path])
+        .spawn()?;
     Ok(())
 }
 

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -49,10 +49,7 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 
 fn open_with_app(app: &str, command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let path = write_temp_script(command, env_vars)?;
-    Command::new("open")
-        .envs(env_vars)
-        .args(["-a", app, path])
-        .spawn()?;
+    Command::new("open").args(["-a", app, path]).spawn()?;
     Ok(())
 }
 
@@ -117,6 +114,14 @@ fn to_hashbang(shell: String) -> String {
     } else {
         format!("#!/usr/bin/env {}", shell)
     }
+}
+
+fn stringify_env_vars(env_vars: HashMap<String, String>) -> String {
+    env_vars
+        .iter()
+        .map(|(key, value)| format!("{}='{}'", key, value))
+        .collect::<Vec<String>>()
+        .join(" ")
 }
 
 fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result<PathBuf, Error> {

--- a/lib/src/terminal_windows.rs
+++ b/lib/src/terminal_windows.rs
@@ -1,22 +1,19 @@
-use std::collections::HashMap;
-use std::{
-    env::home_dir,
-    env::temp_dir,
-    fs::File,
-    io::Write,
-    path::PathBuf,
-    process::Command,
-};
-use shlex::Shlex;
-
 use crate::{Error, Terminal};
+use shlex::Shlex;
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::{env::home_dir, env::temp_dir, fs::File, io::Write, path::PathBuf, process::Command};
 
-pub(crate) fn open(terminal: Terminal, command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
+pub(crate) fn open(
+    terminal: Terminal,
+    command: &str,
+    env_vars: HashMap<String, String>,
+) -> Result<(), Error> {
     return match terminal {
         Terminal::WindowsDefault => open_with_cmd(command, env_vars),
         Terminal::WSL => open_with_wsl(command, env_vars),
         _ => return Err(Error::NotSupported),
-    }
+    };
 }
 
 pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
@@ -28,57 +25,45 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 }
 
 fn open_with_wsl(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
-    let path = write_temp_script(command, env_vars)?;
+    let path = write_temp_script(command)?;
     let mut cmd = Command::new("wt.exe");
-
-    cmd.current_dir(path.parent().unwrap())
-        .arg("wsl")
-        .arg("--")
-        .arg(format!("./{:?}", path.file_name().unwrap()));
-
-    match cmd.spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+    let dir = match path.parent() {
+        Some(dir) => dir,
+        None => new_error("Invalid path"),
+    };
+    let file_name = match path.file_name() {
+        Some(file_name) => file_name,
+        None => new_error("Invalid filename"),
+    };
+    cmd.current_dir(dir)
+        .envs(env_vars)
+        .args(["wsl", "--", format!("./{:?}", file_name)])
+        .spawn()?;
+    Ok(())
 }
 
 fn open_with_cmd(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let args: Vec<String> = Shlex::new(command).collect();
     let mut cmd = Command::new("cmd.exe");
-
     cmd.current_dir(cwd())
-       .arg("/c")
-       .arg("start")
-       .arg("cmd")
-       .arg("/k")
-       .args(args);
-
-    for (key, value) in env_vars.iter() {
-        cmd.env(key, value);
-    }
-
-    match cmd.spawn() {
-        Ok(_) => Ok(()),
-        Err(err) => Err(Error::IOError(err)),
-    }
+        .envs(env_vars)
+        .args(["/c", "start", "cmd", "/k"].iter().chain(args))
+        .spawn()?;
+    Ok(())
 }
 
-fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result<PathBuf, Error> {
+fn write_temp_script(command: &str) -> Result<PathBuf, Error> {
     let dir = temp_dir();
     let path = dir.join("run-in-terminal.sh");
 
-    let mut f = File::create(&path).map_err(Error::IOError)?;
-
-    let set_env = stringify_env_vars(env_vars);
+    let mut f = File::create(&path)?;
 
     let content = if command.is_empty() {
-        format!("#!/usr/bin/env sh\n\n{} exec $SHELL", set_env)
+        format!("#!/usr/bin/env sh\n\n exec $SHELL")
     } else {
-        format!("#!/usr/bin/env sh\n\n{} {}\n{} exec $SHELL", set_env, command, set_env)
+        format!("#!/usr/bin/env sh\n\n{} exec $SHELL", command)
     };
-    f.write_all(content.as_bytes())
-        .and_then(|_| f.flush())
-        .map_err(Error::IOError)?;
+    f.write_all(content.as_bytes()).and_then(|_| f.flush())?;
     Ok(path)
 }
 
@@ -86,10 +71,6 @@ fn cwd() -> PathBuf {
     home_dir().unwrap_or(temp_dir())
 }
 
-fn stringify_env_vars(env_vars: HashMap<String, String>) -> String {
-    env_vars
-        .iter()
-        .map(|(key, value)| format!("{}='{}'", key, value))
-        .collect::<Vec<String>>()
-        .join(" ")
+fn new_error(message: &str) -> Error {
+    Error::IOError(io::Error::new(ErrorKind::Other, message))
 }

--- a/lib/src/terminal_windows.rs
+++ b/lib/src/terminal_windows.rs
@@ -1,7 +1,6 @@
 use crate::{Error, Terminal};
 use shlex::Shlex;
 use std::collections::HashMap;
-use std::io::ErrorKind;
 use std::{env::home_dir, env::temp_dir, fs::File, io::Write, path::PathBuf, process::Command};
 
 pub(crate) fn open(
@@ -25,19 +24,12 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
 }
 
 fn open_with_wsl(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
-    let path = write_temp_script(command)?;
-    let mut cmd = Command::new("wt.exe");
-    let dir = match path.parent() {
-        Some(dir) => dir,
-        None => new_error("Invalid path"),
-    };
-    let file_name = match path.file_name() {
-        Some(file_name) => file_name,
-        None => new_error("Invalid filename"),
-    };
-    cmd.current_dir(dir)
-        .envs(env_vars)
-        .args(["wsl", "--", format!("./{:?}", file_name)])
+    let path = write_temp_script(command, env_vars)?;
+    Command::new("wt.exe")
+        .current_dir(path.parent().unwrap())
+        .arg("wsl")
+        .arg("--")
+        .arg(format!("./{:?}", path.file_name().unwrap()))
         .spawn()?;
     Ok(())
 }
@@ -45,23 +37,33 @@ fn open_with_wsl(command: &str, env_vars: HashMap<String, String>) -> Result<(),
 fn open_with_cmd(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let args: Vec<String> = Shlex::new(command).collect();
     let mut cmd = Command::new("cmd.exe");
-    cmd.current_dir(cwd())
-        .envs(env_vars)
-        .args(["/c", "start", "cmd", "/k"].iter().chain(args))
-        .spawn()?;
+    cmd.current_dir(cwd()).arg("/c").arg("start").arg("cmd").arg("/k").args(args);
+    for (key, value) in env_vars.iter() {
+        cmd.env(key, value);
+    }
+    cmd.spawn()?;
     Ok(())
 }
 
-fn write_temp_script(command: &str) -> Result<PathBuf, Error> {
+fn stringify_env_vars(env_vars: HashMap<String, String>) -> String {
+    env_vars
+        .iter()
+        .map(|(key, value)| format!("{}='{}'", key, value))
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
+fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result<PathBuf, Error> {
     let dir = temp_dir();
     let path = dir.join("run-in-terminal.sh");
 
     let mut f = File::create(&path)?;
 
+    let set_env = stringify_env_vars(env_vars);
     let content = if command.is_empty() {
-        format!("#!/usr/bin/env sh\n\n exec $SHELL")
+        format!("#!/usr/bin/env sh\n\n{} exec $SHELL", set_env)
     } else {
-        format!("#!/usr/bin/env sh\n\n{} exec $SHELL", command)
+        format!("#!/usr/bin/env sh\n\n{} {}\n{} exec $SHELL", set_env, command, set_env)
     };
     f.write_all(content.as_bytes()).and_then(|_| f.flush())?;
     Ok(path)
@@ -69,8 +71,4 @@ fn write_temp_script(command: &str) -> Result<PathBuf, Error> {
 
 fn cwd() -> PathBuf {
     home_dir().unwrap_or(temp_dir())
-}
-
-fn new_error(message: &str) -> Error {
-    Error::IOError(io::Error::new(ErrorKind::Other, message))
 }


### PR DESCRIPTION
Some refactoring.

* Implement From<io::Error> for Error in lib
   This should simplify error handling from all open implementations

Linux:

* remove all map_err calls, since the conversion is done by the From implementation
* remove all error handling from all the open_* functions and just call them spawn_* instead

Mac:

* remove all map_err calls since conversion is done by the From implementation
* collapse repetitive .arg().arg()... into one .args([])
* use the .envs() function for creating the environment instead of formatting them into the temporary script.
   Using formatting to write envs in the script is prone to formatting issues (eg. if the variable data contains a ")

Windows:

* remove all map_err calls since conversion is done by the From implementation
* collapse repetitive .arg().arg()... into one .args([])
* replace for loop calling .env() into just .envs()
* use the .envs() function for creating the environment instead of formatting them into the temporary script.
   Using formatting to write envs in the script is prone to formatting issues (eg. if the variable data contains a ")
