### PR TITLE
Add support for Tabby on macOS & Interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is currently used by [Aptakube](https://aptakube.com).
 - Warp
 - Ghostty
 - Kitty
+- Tabby
 - WezTerm
 
 ## Windows

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,7 +22,8 @@ pub enum Terminal {
     GNOMETerminal,
     Konsole,
     Kitty,
-    Ghostty
+    Ghostty,
+    Tabby
 }
 
 #[derive(Debug)]

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -84,9 +84,9 @@ fn write_temp_script(command: &str, env_vars: HashMap<String, String>) -> Result
     let mut f = File::create(&path).map_err(Error::IOError)?;
 
     let content = if command.is_empty() {
-        format!("#!/usr/bin/env zsh\n\n{} exec $SHELL", stringify_env_vars(env_vars))
+        format!("#!/usr/bin/env zsh -il\n\n{} exec $SHELL", stringify_env_vars(env_vars))
     } else {
-        format!("#!/usr/bin/env zsh\n\n{} {}\nexec $SHELL", stringify_env_vars(env_vars), command)
+        format!("#!/usr/bin/env zsh -il\n\n{} {}\nexec $SHELL", stringify_env_vars(env_vars), command)
     };
 
     f.write_all(content.as_bytes()).and_then(|_| f.flush()).map_err(Error::IOError)?;

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -14,6 +14,7 @@ pub(crate) fn open(terminal: Terminal, command: &str, env_vars: HashMap<String, 
         Terminal::Warp => open_with_app("warp", command, env_vars),
         Terminal::Ghostty => open_with_app("ghostty", command, env_vars),
         Terminal::Kitty => open_with_app("kitty", command, env_vars),
+        Terminal::Tabby => open_with_tabby(command, env_vars),
         Terminal::WezTerm => open_with_wezterm(command, env_vars),
         _ => return Err(Error::NotSupported),
     }
@@ -27,6 +28,7 @@ pub(crate) fn is_installed(terminal: Terminal) -> Result<bool, Error> {
         Terminal::WezTerm => "WezTerm",
         Terminal::Ghostty => "Ghostty",
         Terminal::Kitty => "Kitty",
+        Terminal::Tabby => "Tabby",
         _ => return Err(Error::NotSupported),
     };
 
@@ -59,6 +61,17 @@ fn open_with_wezterm(command: &str, env_vars: HashMap<String, String>) -> Result
     let path = write_temp_script(command, env_vars)?;
 
     match Command::new("open").arg("-na").arg("wezterm").arg("--args").arg("start").arg("--").arg(path).spawn() {
+        Ok(_) => Ok(()),
+        Err(err) => Err(Error::IOError(err)),
+    }
+}
+
+fn open_with_tabby(command: &str, mut env_vars: HashMap<String, String>) -> Result<(), Error> {
+    env_vars.entry("PATH".into()).or_insert_with(|| std::env::var("PATH").unwrap_or_default());
+    
+    let path = write_temp_script(command, env_vars)?;
+
+    match Command::new("open").arg("-na").arg("Tabby").arg("--args").arg("run").arg(path).spawn() {
         Ok(_) => Ok(()),
         Err(err) => Err(Error::IOError(err)),
     }

--- a/lib/src/terminal_macos.rs
+++ b/lib/src/terminal_macos.rs
@@ -66,9 +66,7 @@ fn open_with_wezterm(command: &str, env_vars: HashMap<String, String>) -> Result
     }
 }
 
-fn open_with_tabby(command: &str, mut env_vars: HashMap<String, String>) -> Result<(), Error> {
-    env_vars.entry("PATH".into()).or_insert_with(|| std::env::var("PATH").unwrap_or_default());
-    
+fn open_with_tabby(command: &str, env_vars: HashMap<String, String>) -> Result<(), Error> {
     let path = write_temp_script(command, env_vars)?;
 
     match Command::new("open").arg("-na").arg("Tabby").arg("--args").arg("run").arg(path).spawn() {

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,7 @@
             <option value="Ghostty">Ghostty</option>
             <option value="Kitty">Kitty</option>
             <option value="WezTerm">WezTerm</option>
+            <option value="Tabby">Tabby</option>
           </optgroup>
           <optgroup label="Windows">
             <option value="WindowsDefault">Windows Default</option>


### PR DESCRIPTION
PR adds support for [tabby](https://tabby.sh/) on macOS.

Also added two parameters when launching zsh so it opens as login & interactive shell — making it a login shell ensures that usual profile files (like ~/.zprofile or ~/.zlogin) get loaded, while interactive mode keeps features like prompt rendering turned on.

This has been tested on my device without issues.